### PR TITLE
cohort API against missing MONGO_URI

### DIFF
--- a/src/app/api/cohort/route.ts
+++ b/src/app/api/cohort/route.ts
@@ -2,18 +2,28 @@
 import { NextResponse } from 'next/server';
 import { MongoClient } from 'mongodb';
 
-
-const uri = process.env.MONGO_URI!;
-const client = new MongoClient(uri);
 const dbName = 'cohortDB';
 const collectionName = 'cohortData';
 
 export async function GET() {
+  const uri = process.env.MONGO_URI;
+  
+  if (!uri) {
+    return NextResponse.json(
+      { error: 'MONGO_URI environment variable is not set' },
+      { status: 500 }
+    );
+  }
+
+  const client = new MongoClient(uri);
+
   try {
     await client.connect();
     const data = await client.db(dbName).collection(collectionName).find({}).toArray();
     return NextResponse.json(data);
   } catch (error) {
     return NextResponse.json({ error: 'Failed to fetch data' }, { status: 500 });
+  } finally {
+    await client.close();
   }
 }


### PR DESCRIPTION
## 📌 Description

Validate `MONGO_URI` and late instantiate `MongoClient` in the cohort API so a missing env var returns a clear 500 JSON error instead of crashing the server.


Fixes #73 
---
## ✅ Changes
Move `new MongoClient(uri)` inside the `GET()` handler and validate `MONGO_URI` before use and return `{ error: "MONGO_URI environment variable is not set"}` with status 500 when missing
- [x] Fix

---

## 📷 Screenshots / Demo (if applicable)


---
## Checklist

- [x] I have tested this code
- [x] I have added necessary documentation
- [x] I have linked relevant issue(s)
- [x] I followed the code style of the project
- [x] I reviewed my own code
