### PR TITLE
fix: add explicit TypeScript return types to utility functions

### DIFF
--- a/src/lib/data-processing.ts
+++ b/src/lib/data-processing.ts
@@ -3,7 +3,7 @@ import {
   EngagementData, ProcessedData, TechPartnerMetrics,
   TechPartnerPerformance, ContributorDetails, IssueResult,
   IssueHighlight, EnhancedTechPartnerData, ActionItem,
-  GitHubData, IssueMetrics, EngagementTrend
+  GitHubData, IssueMetrics, EngagementTrend, TopPerformer, TechnicalProgress
 } from '@/types/dashboard';
 import * as utils from './utils';
 
@@ -202,7 +202,7 @@ function calculatePositiveFeedback(data: EngagementData[]): number {
 }
 
 // Calculate Top Performers
-function calculateTopPerformers(data: EngagementData[]) {
+function calculateTopPerformers(data: EngagementData[]): TopPerformer[] {
   return _(data)
     .groupBy('Name')
     .map((entries, name) => ({
@@ -223,7 +223,7 @@ function calculateTopPerformers(data: EngagementData[]) {
 }
 
 // Calculate Tech Partner Metrics
-function calculateTechPartnerMetrics(data: EngagementData[]) {
+function calculateTechPartnerMetrics(data: EngagementData[]): TechPartnerMetrics[] {
   return _(data)
     .groupBy('Which Tech Partner')
     .map((items, partner) => ({
@@ -729,7 +729,7 @@ function calculateEngagementTrends(csvData: any[]): EngagementTrend[] {
   });
 }
 
-function calculateTechnicalProgress(csvData: any[], githubData?: GitHubData | null) {
+function calculateTechnicalProgress(csvData: any[], githubData?: GitHubData | null): TechnicalProgress[] {
   return Object.entries(_.groupBy(csvData, 'Program Week'))
     .sort((a, b) => parseWeekNumber(a[0]) - parseWeekNumber(b[0]))
     .map(([week, entries]) => ({

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,4 +1,4 @@
-import { GitHubData, GitHubUserContribution, DashboardMetrics, ValidatedContribution } from '@/types/dashboard';
+import { GitHubData, GitHubUserContribution, DashboardMetrics, ValidatedContribution, EngagementTrend, TechnicalProgress, TechPartnerPerformance, ContributorGrowth } from '@/types/dashboard';
 
 export function calculateMetrics({
   projectBoard,
@@ -91,7 +91,13 @@ export function generateTrendData(data: {
   projectBoard: GitHubData;
   userContributions: Record<string, GitHubUserContribution>;
   validatedContributions: Record<string, ValidatedContribution>;
-}) {
+}): {
+  engagement: EngagementTrend[];
+  technical: TechnicalProgress[];
+  techPartner: TechPartnerPerformance[];
+  techPartnerPerformance: TechPartnerPerformance[];
+  contributorGrowth: ContributorGrowth[];
+} {
   const {
     projectBoard = { issues: [] },
     userContributions = {},


### PR DESCRIPTION
Related to #68 
## Summary

* Added explicit return types to `calculateTopPerformers`, `calculateTechPartnerMetrics`, and `calculateTechnicalProgress` in `src/lib/data-processing.ts`
* Added explicit return type to `generateTrendData` in `src/lib/metrics.ts`
* Added required imports: `TopPerformer`, `TechnicalProgress`, `EngagementTrend`, `TechPartnerPerformance`, and `ContributorGrowth`

## Improvements

* Improves TypeScript type safety by catching errors at compile time
* Makes function contracts more explicit and easier to understand
* Improves IDE support with better autocomplete and inline documentation
* Follows TypeScript best practices for maintainability and long-term scalability

## Files Changed

* `src/lib/data-processing.ts` — added explicit return types to 3 functions
* `src/lib/metrics.ts` — added explicit return type with complete type definition
